### PR TITLE
chore: Update genai-rs to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "genai-rs"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d98b3fb8915b5e6f1f87d50c46a70e39e6c145de4dd75a918b42f6dd26b7ce"
+checksum = "7245e4596f39a239a8e603c9b4b5d4c1ccbf54e6a5e400a87917ac0c8d029f1a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -322,7 +322,6 @@ dependencies = [
  "futures-util",
  "genai-rs-macros",
  "inventory",
- "log",
  "regex",
  "reqwest",
  "serde",
@@ -330,14 +329,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "urlencoding",
 ]
 
 [[package]]
 name = "genai-rs-macros"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d460a13fd61d52cb8021cdf820e99207aab583b24efab693655d43efb7a67961"
+checksum = "d519e6922f4c74e9af8dcb9b24af203763fb525965950daca8023f622e2cffe0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1582,7 +1582,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "read_files"
 path = "src/main.rs"
 
 [dependencies]
-genai-rs = "0.5.0"
+genai-rs = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/gemini_utils.rs
+++ b/src/gemini_utils.rs
@@ -41,7 +41,7 @@ pub async fn call_gemini_with_schema(
         .create()
         .await?;
     
-    Ok(response.text().unwrap_or_default().to_string())
+    Ok(response.as_text().unwrap_or_default().to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Update genai-rs dependency from 0.5.0 to 0.7.0
- Adapt to API change: `response.text()` → `response.as_text()`

## Test plan
- [x] All 24 unit tests pass
- [x] Verified end-to-end API call works with test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)